### PR TITLE
feat: implement persistent SPIFFS log system with web UI controls

### DIFF
--- a/Firmware/flex-fsk-tx-v3.6_WiFi/flex-fsk-tx-v3.6_WiFi.ino
+++ b/Firmware/flex-fsk-tx-v3.6_WiFi/flex-fsk-tx-v3.6_WiFi.ino
@@ -192,9 +192,19 @@
  * v3.6.102 - MQTT ACTIVITY CLEANUP: Removed redundant "Status Published" event from Recent Activity (mqtt_publish_status is just ACK to broker, not separate event), transmission checkmark in metadata now only appears for events that actually transmit RF (Message Received, Suspended), connection events (Connected/Disconnected) show only datetime
  * v3.6.103 - CHATGPT JSON ESCAPE FIX: Added json_escape_string() for proper JSON encoding, sanitize_chatgpt_prompt() for
  *            input normalization (whitespace/newlines), prevents HTTP 400 errors from malformed JSON with special characters
+ * v3.6.104 - PERSISTENT SPIFFS LOG SYSTEM: Implemented /serial.log file (250KB limit, 50KB keep on rotate),
+ *            single logMessage() function handles all logging (Serial + file + syslog), deleted old log buffers
+ *            (12KB freed), pre-NTP timestamps show uptime (0000-00-00 HH:MM:SS), post-NTP show datetime
+ *            (YYYY-MM-DD HH:MM:SS), file.flush() ensures writes committed to flash, AT+GETLOG=N (default 25)
+ *            and AT+RMLOG commands, status page displays 100 lines with auto-scroll to bottom, chronological
+ *            order (oldest→newest), live logs toggle with configurable refresh interval (1-60s, default 5s)
+ *            and lines count (10-500, default 100), both apply immediately on blur, simple polling every N
+ *            seconds (no timestamp filtering), scrollable container (500px max-height), download button,
+ *            /logs API accepts ?lines=N parameter, boot logging starts immediately after SPIFFS init,
+ *            sendSyslog() now detects severity internally (moved from logMessage for better encapsulation)
 */
 
-#define CURRENT_VERSION "v3.6.103"
+#define CURRENT_VERSION "v3.6.104"
 
 /*
  * ============================================================================
@@ -344,7 +354,8 @@
 #define CONFIG_MAGIC 0xF1E7
 #define CONFIG_VERSION 3
 
-#define SERIAL_LOG_SIZE 20
+#define MAX_LOG_FILE_SIZE 256000
+#define LOG_TRUNCATE_SIZE 51200
 
 #define CHECK_HEAP(size) (ESP.getFreeHeap() > (size + 8192))
 
@@ -586,14 +597,6 @@ struct BootFailureTracker {
 };
 
 BootFailureTracker boot_tracker = {0, 0};
-
-struct SerialLogEntry {
-    unsigned long timestamp;
-    char message[100];
-};
-SerialLogEntry serial_log[SERIAL_LOG_SIZE];
-int serial_log_index = 0;
-int serial_log_count = 0;
 
 CoreConfig core_config;
 DeviceSettings settings;
@@ -2096,11 +2099,13 @@ String formatSyslogMessage(const String& message, uint8_t severity) {
     return "<" + String(priority) + ">" + String(timestamp) + " " + hostname + " " + mac_suffix + ": " + message;
 }
 
-void sendSyslog(const String& message, uint8_t severity) {
+void sendSyslog(const String& message) {
     if (!settings.rsyslog_enabled) return;
-    if (severity > settings.rsyslog_min_severity) return;
     if (strlen(settings.rsyslog_server) == 0) return;
     if (!wifi_connected) return;
+
+    uint8_t severity = detectSeverity(message);
+    if (severity > settings.rsyslog_min_severity) return;
 
     String syslogMsg = formatSyslogMessage(message, severity);
 
@@ -2125,9 +2130,9 @@ float apply_frequency_correction(float base_freq) {
 
 
 void logMessage(const char* message) {
-    log_serial_message(message);
-    uint8_t severity = detectSeverity(String(message));
-    sendSyslog(String(message), severity);
+    Serial.println(message);
+    append_to_log_file(message);
+    sendSyslog(String(message));
 }
 
 void logMessage(const String& message) {
@@ -8116,23 +8121,75 @@ void handle_grafana_toggle() {
 void handle_logs() {
     reset_oled_timeout();
 
+    int numLines = 20;
+    if (webServer.hasArg("lines")) {
+        numLines = webServer.arg("lines").toInt();
+        if (numLines <= 0) numLines = 20;
+    }
+
+    String logs = read_log_tail(numLines);
     String response = "{\"logs\":[";
 
-    for (int i = 0; i < serial_log_count && i < 20; i++) {
-        int index = (serial_log_index - 1 - i + SERIAL_LOG_SIZE) % SERIAL_LOG_SIZE;
-        if (index < 0) index += SERIAL_LOG_SIZE;
+    int lineStart = 0;
+    int lineCount = 0;
 
-        if (i > 0) response += ",";
-        response += "{";
-        response += "\"message\":\"" + String(serial_log[index].message) + "\",";
-        response += "\"type\":\"info\",";
-        response += "\"timestamp\":" + String(serial_log[index].timestamp);
-        response += "}";
+    for (int i = 0; i < logs.length(); i++) {
+        if (logs[i] == '\n') {
+            String line = logs.substring(lineStart, i);
+            lineStart = i + 1;
+
+            if (lineCount > 0) response += ",";
+
+            String timestamp = "";
+            String message = line;
+
+            if (line.length() > 20) {
+                timestamp = line.substring(0, 19);
+                message = line.substring(20);
+            }
+
+            response += "{";
+            response += "\"timestamp\":\"" + timestamp + "\",";
+            response += "\"message\":\"" + message + "\"";
+            response += "}";
+
+            lineCount++;
+        }
     }
 
     response += "]}";
 
     webServer.send(200, "application/json", response);
+}
+
+void handle_download_logs() {
+    reset_oled_timeout();
+
+    if (!SPIFFS.exists("/serial.log")) {
+        webServer.send(404, "text/plain", "Log file not found");
+        return;
+    }
+
+    File file = SPIFFS.open("/serial.log", "r");
+    if (!file) {
+        webServer.send(500, "text/plain", "Failed to open log file");
+        return;
+    }
+
+    webServer.sendHeader("Content-Type", "text/plain");
+    webServer.sendHeader("Content-Disposition", "attachment; filename=\"serial.log\"");
+    webServer.sendHeader("Content-Length", String(file.size()));
+
+    webServer.setContentLength(file.size());
+    webServer.send(200, "text/plain", "");
+
+    uint8_t buffer[512];
+    while (file.available()) {
+        size_t len = file.readBytes((char*)buffer, 512);
+        webServer.client().write(buffer, len);
+    }
+
+    file.close();
 }
 
 void handle_device_status() {
@@ -8494,43 +8551,66 @@ void handle_device_status() {
     chunk += "<div style='border: 2px solid var(--theme-border); border-radius: 8px; padding: 20px; background-color: var(--theme-card); margin-bottom: 20px;'>";
     chunk += "<div style='display: flex; justify-content: space-between; align-items: center; margin-bottom: 15px;'>";
     chunk += "<h3 style='margin: 0;'>📡 Recent Serial Messages</h3>";
-    chunk += "<div style='display: flex; align-items: center; gap: 8px;'>";
+    chunk += "<div style='display: flex; align-items: center; gap: 8px; flex-wrap: wrap;'>";
     chunk += "<div class='toggle-switch' id='live-logs-toggle' onclick='toggleLiveLogs()' style='background-color: #ccc;'>";
     chunk += "<div class='toggle-slider' style='left: 2px;'></div>";
     chunk += "</div>";
     chunk += "<span style='font-size: 0.9em; color: var(--theme-text);'>Live Logs</span>";
+    chunk += "<label style='display:flex;align-items:center;gap:5px;'>";
+    chunk += "<span style='font-size:0.9em;'>Interval:</span>";
+    chunk += "<input type='number' id='refresh-interval' value='5' min='1' max='60' style='width:50px;padding:4px 6px;border:1px solid var(--theme-border);border-radius:4px;background-color:var(--theme-input);color:var(--theme-text);' onblur='updateRefreshInterval()'>";
+    chunk += "<span style='font-size:0.9em;'>s</span>";
+    chunk += "</label>";
+    chunk += "<label style='display:flex;align-items:center;gap:5px;'>";
+    chunk += "<span style='font-size:0.9em;'>Lines:</span>";
+    chunk += "<input type='number' id='lines-count' value='100' min='10' max='500' style='width:60px;padding:4px 6px;border:1px solid var(--theme-border);border-radius:4px;background-color:var(--theme-input);color:var(--theme-text);' onblur='updateLinesToShow()'>";
+    chunk += "</label>";
+    chunk += "<a href='/download_logs' download='serial.log'><button style='padding:6px 10px;font-size:0.8em;background-color:#007bff;color:white;border-radius:4px;border:none;cursor:pointer;'>📥 Download</button></a>";
     chunk += "</div>";
     chunk += "</div>";
 
     webServer.sendContent(chunk);
     chunk = "";
 
-    if (serial_log_count == 0) {
-        chunk += "<p>No serial messages logged yet.</p>";
+    String logs = read_log_tail(100);
+
+    if (logs.length() == 0) {
+        chunk += "<p>No log entries found.</p>";
     } else {
+        chunk += "<style>.serial-log{max-height:500px;overflow-y:auto;}</style>";
         chunk += "<div class='serial-log'>";
         webServer.sendContent(chunk);
         chunk = "";
 
-        for (int i = 0; i < serial_log_count; i++) {
-            int index = (serial_log_index - 1 - i + SERIAL_LOG_SIZE) % SERIAL_LOG_SIZE;
-            if (index < 0) index += SERIAL_LOG_SIZE;
+        int lineStart = 0;
+        int lineCount = 0;
 
-            time_t timestamp = serial_log[index].timestamp + (settings.timezone_offset_hours * 3600);
-            struct tm *timeinfo = localtime(&timestamp);
-            char timeStr[20];
-            strftime(timeStr, sizeof(timeStr), "%H:%M:%S", timeinfo);
+        for (int i = 0; i < logs.length(); i++) {
+            if (logs[i] == '\n') {
+                String line = logs.substring(lineStart, i);
+                lineStart = i + 1;
 
-            chunk += "<div>";
-            chunk += "<span class='timestamp'>[" + String(timeStr) + "]</span> ";
-            chunk += String(serial_log[index].message);
-            chunk += "</div>";
+                int spacePos = line.indexOf(' ', 11);
+                if (spacePos > 0) {
+                    String timestamp = line.substring(0, spacePos);
+                    String message = line.substring(spacePos + 1);
 
-            if ((i + 1) % 10 == 0) {
-                webServer.sendContent(chunk);
-                chunk = "";
+                    chunk += "<div>";
+                    chunk += "<span class='timestamp'>" + timestamp + "</span> ";
+                    chunk += message;
+                    chunk += "</div>";
+                } else {
+                    chunk += "<div>" + line + "</div>";
+                }
+
+                lineCount++;
+                if (lineCount % 10 == 0) {
+                    webServer.sendContent(chunk);
+                    chunk = "";
+                }
             }
         }
+
         if (chunk.length() > 0) {
             webServer.sendContent(chunk);
             chunk = "";
@@ -8538,6 +8618,10 @@ void handle_device_status() {
         chunk += "</div>";
     }
     chunk += "</div>";
+    chunk += "<script>document.addEventListener('DOMContentLoaded', function() {"
+             "const container = document.querySelector('.serial-log');"
+             "if (container) container.scrollTop = container.scrollHeight;"
+             "});</script>";
 
     webServer.sendContent(chunk);
     chunk = "";
@@ -8567,33 +8651,74 @@ void handle_device_status() {
     chunk += "</div>";
     chunk += "</div>";
     chunk += "<script>"
-           "let lastLogTimestamp = 0;"
            "let liveLogsEnabled = false;"
            "let liveLogsInterval = null;"
+           "let refreshInterval = 5000;"
+           "let linesToShow = 100;"
            "function pollLogs() {"
-           "  fetch('/logs')"
+           "  fetch('/logs?lines=' + linesToShow)"
            "    .then(response => response.json())"
            "    .then(data => {"
+           "      const container = document.querySelector('.serial-log');"
+           "      if (!container) return;"
+           "      container.innerHTML = '';"
            "      if (data.logs && data.logs.length > 0) {"
-           "        const container = document.querySelector('.serial-log');"
-           "        if (!container) return;"
-           "        let newLogs = [];"
            "        data.logs.forEach(log => {"
-           "          if (log.timestamp > lastLogTimestamp) {"
-           "            newLogs.push(log);"
-           "            lastLogTimestamp = Math.max(lastLogTimestamp, log.timestamp);"
-           "          }"
-           "        });"
-           "        newLogs.reverse().forEach(log => {"
            "          const logDiv = document.createElement('div');"
-           "          const date = new Date(log.timestamp * 1000);"
-           "          const timeStr = date.toLocaleTimeString('en-US', {hour12: false, hour: '2-digit', minute: '2-digit', second: '2-digit'});"
-           "          logDiv.innerHTML = \"<span class='timestamp'>[\" + timeStr + \"]</span> \" + log.message;"
-           "          container.insertBefore(logDiv, container.firstChild);"
+           "          logDiv.innerHTML = \"<span class='timestamp'>\" + log.timestamp + \"</span> \" + log.message;"
+           "          container.appendChild(logDiv);"
            "        });"
+           "      } else {"
+           "        container.innerHTML = '<p>No log entries found.</p>';"
            "      }"
            "    })"
-           "    .catch(() => {});"
+           "    .catch(() => {"
+           "      container.innerHTML = '<div style=\"color:red;\">Failed to load logs</div>';"
+           "    });"
+           "}"
+           "function loadLogs(lines) {"
+           "  const container = document.querySelector('.serial-log');"
+           "  if (!container) return;"
+           "  container.innerHTML = '<div style=\"text-align:center;padding:20px;\">Loading...</div>';"
+           "  fetch('/logs?lines=' + lines)"
+           "    .then(response => response.json())"
+           "    .then(data => {"
+           "      container.innerHTML = '';"
+           "      if (data.logs && data.logs.length > 0) {"
+           "        data.logs.forEach(log => {"
+           "          const logDiv = document.createElement('div');"
+           "          logDiv.innerHTML = \"<span class='timestamp'>\" + log.timestamp + \"</span> \" + log.message;"
+           "          container.appendChild(logDiv);"
+           "        });"
+           "      } else {"
+           "        container.innerHTML = '<p>No log entries found.</p>';"
+           "      }"
+           "    })"
+           "    .catch(() => {"
+           "      container.innerHTML = '<div style=\"color:red;\">Failed to load logs</div>';"
+           "    });"
+           "}"
+           "function updateRefreshInterval() {"
+           "  const input = document.getElementById('refresh-interval');"
+           "  const seconds = parseInt(input.value);"
+           "  if (seconds >= 1 && seconds <= 60) {"
+           "    refreshInterval = seconds * 1000;"
+           "    if (liveLogsEnabled) {"
+           "      clearInterval(liveLogsInterval);"
+           "      liveLogsInterval = setInterval(pollLogs, refreshInterval);"
+           "    }"
+           "  } else {"
+           "    input.value = refreshInterval / 1000;"
+           "  }"
+           "}"
+           "function updateLinesToShow() {"
+           "  const input = document.getElementById('lines-count');"
+           "  const lines = parseInt(input.value);"
+           "  if (lines >= 10 && lines <= 500) {"
+           "    linesToShow = lines;"
+           "  } else {"
+           "    input.value = linesToShow;"
+           "  }"
            "}"
            "function toggleLiveLogs() {"
            "  liveLogsEnabled = !liveLogsEnabled;"
@@ -8602,7 +8727,8 @@ void handle_device_status() {
            "  if (liveLogsEnabled) {"
            "    toggle.style.backgroundColor = '#28a745';"
            "    slider.style.left = '26px';"
-           "    liveLogsInterval = setInterval(pollLogs, 2000);"
+           "    liveLogsInterval = setInterval(pollLogs, refreshInterval);"
+           "    pollLogs();"
            "  } else {"
            "    toggle.style.backgroundColor = '#ccc';"
            "    slider.style.left = '2px';"
@@ -8610,9 +8736,9 @@ void handle_device_status() {
            "      clearInterval(liveLogsInterval);"
            "      liveLogsInterval = null;"
            "    }"
+           "    loadLogs(linesToShow);"
            "  }"
            "}"
-           "pollLogs();"
            "</script>";
 
     chunk += get_html_footer();
@@ -9458,27 +9584,112 @@ void handle_upload_certificate() {
     uploaded_cert_data = "";
 }
 
+void trim_log_file() {
+    File file = SPIFFS.open("/serial.log", "r");
+    if (!file) return;
 
+    size_t fileSize = file.size();
+    if (fileSize <= MAX_LOG_FILE_SIZE) {
+        file.close();
+        return;
+    }
 
+    size_t keepPosition = fileSize - LOG_TRUNCATE_SIZE;
+    file.seek(keepPosition);
 
+    while (file.available() && file.read() != '\n');
 
+    File tmpFile = SPIFFS.open("/serial.tmp", "w");
+    uint8_t buffer[512];
 
+    while (file.available()) {
+        size_t len = file.readBytes((char*)buffer, 512);
+        tmpFile.write(buffer, len);
+        yield();
+    }
 
+    file.close();
+    tmpFile.close();
 
+    SPIFFS.remove("/serial.log");
+    SPIFFS.rename("/serial.tmp", "/serial.log");
+}
 
+void append_to_log_file(const char* message) {
+    char logLine[256];
 
-void log_serial_message(const char* message) {
-    Serial.println(message);
+    if (!ntp_synced) {
+        unsigned long uptime_seconds = millis() / 1000;
+        unsigned long hours = (uptime_seconds / 3600) % 24;
+        unsigned long minutes = (uptime_seconds / 60) % 60;
+        unsigned long seconds = uptime_seconds % 60;
+        snprintf(logLine, sizeof(logLine), "0000-00-00 %02lu:%02lu:%02lu %s\n",
+                 hours, minutes, seconds, message);
+    } else {
+        time_t now = getLocalTimestamp();
+        struct tm timeinfo;
+        localtime_r(&now, &timeinfo);
+        snprintf(logLine, sizeof(logLine), "%04d-%02d-%02d %02d:%02d:%02d %s\n",
+                 timeinfo.tm_year + 1900, timeinfo.tm_mon + 1, timeinfo.tm_mday,
+                 timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec, message);
+    }
 
-    serial_log[serial_log_index].timestamp = getUnixTimestamp();
-    strncpy(serial_log[serial_log_index].message, message, sizeof(serial_log[serial_log_index].message) - 1);
-    serial_log[serial_log_index].message[sizeof(serial_log[serial_log_index].message) - 1] = '\0';
+    File file = SPIFFS.open("/serial.log", "a");
+    if (file) {
+        file.print(logLine);
+        file.flush();
+        size_t currentSize = file.size();
+        file.close();
 
-    serial_log_index = (serial_log_index + 1) % SERIAL_LOG_SIZE;
-    if (serial_log_count < SERIAL_LOG_SIZE) {
-        serial_log_count++;
+        if (currentSize > MAX_LOG_FILE_SIZE) {
+            trim_log_file();
+        }
     }
 }
+
+String read_log_tail(int max_lines) {
+    File file = SPIFFS.open("/serial.log", "r");
+    if (!file) return "";
+
+    size_t fileSize = file.size();
+    if (fileSize == 0) {
+        file.close();
+        return "";
+    }
+
+    size_t readSize = min((size_t)(max_lines * 100), fileSize);
+    size_t startPos = fileSize - readSize;
+
+    file.seek(startPos);
+    if (startPos > 0) {
+        while (file.available() && file.read() != '\n');
+    }
+
+    String content = "";
+    while (file.available()) {
+        content += file.readStringUntil('\n') + "\n";
+    }
+    file.close();
+
+    int lineCount = 0;
+    int lastNewline = content.length();
+
+    for (int i = content.length() - 1; i >= 0; i--) {
+        if (content[i] == '\n') {
+            lineCount++;
+            if (lineCount == max_lines) {
+                return content.substring(i + 1);
+            }
+        }
+    }
+
+    return content;
+}
+
+
+
+
+
 
 
 String base64_decode(String input) {
@@ -10549,6 +10760,42 @@ bool at_parse_command(char* cmd_buffer) {
         return true;
     }
 
+    else if (strcmp(cmd_name, "GETLOG") == 0) {
+        if (!SPIFFS.exists("/serial.log")) {
+            Serial.println("ERROR: No log file found");
+            at_send_ok();
+            return true;
+        }
+
+        int numLines = 25;
+        if (equals_pos != NULL) {
+            numLines = atoi(equals_pos + 1);
+            if (numLines <= 0) numLines = 25;
+        }
+
+        String logs = read_log_tail(numLines);
+        Serial.print(logs);
+        at_send_ok();
+        return true;
+    }
+
+    else if (strcmp(cmd_name, "RMLOG") == 0) {
+        if (!SPIFFS.exists("/serial.log")) {
+            Serial.println("ERROR: No log file found");
+            at_send_ok();
+            return true;
+        }
+
+        if (SPIFFS.remove("/serial.log")) {
+            Serial.println("LOG: File deleted");
+            at_send_ok();
+        } else {
+            Serial.println("ERROR: Failed to delete");
+            at_send_ok();
+        }
+        return true;
+    }
+
     return false;
 }
 
@@ -11020,10 +11267,13 @@ void setup() {
             }
         }
     }
+    append_to_log_file("SYSTEM: Device boot started");
     logMessage("SYSTEM: SPIFFS initialized successfully");
 
     load_core_config();
+    append_to_log_file("SYSTEM: Core config loaded");
     load_runtime_settings();
+    append_to_log_file("SYSTEM: Runtime settings loaded");
 
     chatgpt_load_config();
 
@@ -11137,6 +11387,7 @@ void setup() {
         webServer.on("/upload_certificate", HTTP_POST, handle_upload_certificate, handle_file_upload);
         webServer.on("/status", handle_device_status);
         webServer.on("/logs", handle_logs);
+        webServer.on("/download_logs", handle_download_logs);
         webServer.on("/factory_reset", HTTP_POST, handle_web_factory_reset);
         webServer.on("/backup_settings", handle_backup_settings);
         webServer.on("/restore_settings", handle_restore_settings);
@@ -11192,7 +11443,7 @@ void setup() {
     logMessage("STARTUP: HTTP server started on port " + String(settings.http_port));
 
     String startup_msg = "STARTUP: FLEX Paging Message Transmitter " + String(CURRENT_VERSION);
-    log_serial_message(startup_msg.c_str());
+    logMessage(startup_msg.c_str());
 
     Serial.print("AT READY\r\n");
     Serial.print("WIFI ENABLED\r\n");

--- a/Firmware/flex-fsk-tx-v3.6_WiFi/flex-fsk-tx-v3.6_WiFi.ino
+++ b/Firmware/flex-fsk-tx-v3.6_WiFi/flex-fsk-tx-v3.6_WiFi.ino
@@ -209,9 +209,18 @@
  *            still runs to verify/update RTC when network available
  * v3.6.106 - STATUS PAGE UX FIX: Lines count input now refreshes log display immediately when changed,
  *            works even with live logs disabled (calls pollLogs() after updating linesToShow variable)
+ * v3.6.107 - SPIFFS LOG SIZE FIX: Corrected MAX_LOG_FILE_SIZE (256000->32768) and LOG_TRUNCATE_SIZE (51200->8192)
+ *            to fit within 128KB SPIFFS partition (min_spiffs scheme); previous values exceeded partition size
+ *            causing trim to never fire, filling SPIFFS completely and corrupting the filesystem
+ * v3.6.108 - LOG WRITE BUFFER: Replaced per-message open/write/flush/close with 2KB RAM buffer; buffer flushes
+ *            to SPIFFS as single write when full (>=1536B) or every 1s via loop(); eliminates ~88 SPIFFS
+ *            transactions during boot, fixes slow boot and reduces SPIFFS wear significantly
+ * v3.6.109 - SPIFFS WRITE HARDENING: Added file.flush() before file.close() in all config write functions
+ *            (saveCertificateToSPIFFS, save_imap_config, save_runtime_settings, chatgpt_save_config, restore
+ *            handler); restore handler now checks print() return value and logs error on 0-byte write
 */
 
-#define CURRENT_VERSION "v3.6.106"
+#define CURRENT_VERSION "v3.6.109"
 
 /*
  * ============================================================================
@@ -361,8 +370,15 @@
 #define CONFIG_MAGIC 0xF1E7
 #define CONFIG_VERSION 3
 
-#define MAX_LOG_FILE_SIZE 256000
-#define LOG_TRUNCATE_SIZE 51200
+#define MAX_LOG_FILE_SIZE     32768
+#define LOG_TRUNCATE_SIZE     8192
+#define LOG_BUFFER_SIZE       2048
+#define LOG_FLUSH_INTERVAL_MS 1000
+#define LOG_FLUSH_THRESHOLD   (LOG_BUFFER_SIZE * 3 / 4)
+
+static char     log_buffer[LOG_BUFFER_SIZE];
+static size_t   log_buffer_len    = 0;
+static uint32_t log_last_flush_ms = 0;
 
 #define CHECK_HEAP(size) (ESP.getFreeHeap() > (size + 8192))
 
@@ -798,6 +814,7 @@ bool saveCertificateToSPIFFS(const char* filename, const String& cert) {
     }
 
     size_t bytesWritten = file.print(cert);
+    file.flush();
     file.close();
     return (bytesWritten > 0);
 }
@@ -2260,10 +2277,12 @@ bool save_imap_config() {
 
     if (serializeJson(doc, file) == 0) {
         logMessage("IMAP: Failed to write IMAP config JSON");
+        file.flush();
         file.close();
         return false;
     }
 
+    file.flush();
     file.close();
     logMessage("IMAP: Config saved successfully");
     return true;
@@ -2434,10 +2453,12 @@ bool save_runtime_settings() {
 
     if (serializeJson(doc, file) == 0) {
         logMessage("SETTINGS: Failed to write settings JSON");
+        file.flush();
         file.close();
         return false;
     }
 
+    file.flush();
     file.close();
     logMessage("SETTINGS: Configuration saved successfully");
     return true;
@@ -3259,11 +3280,16 @@ bool import_user_backup(const String& json_string, String& error_msg) {
 
         File chatgpt_file = SPIFFS.open("/chatgpt_settings.json", "w");
         if (chatgpt_file) {
-            chatgpt_file.print(chatgpt_json);
+            size_t written = chatgpt_file.print(chatgpt_json);
+            chatgpt_file.flush();
             chatgpt_file.close();
 
-            chatgpt_load_config();
-            logMessage("RESTORE: ChatGPT prompts restored to SPIFFS (" + String(chatgpt_json.length()) + " bytes)");
+            if (written == 0) {
+                logMessage("RESTORE ERROR: ChatGPT prompts write failed (0 bytes)");
+            } else {
+                chatgpt_load_config();
+                logMessage("RESTORE: ChatGPT prompts restored to SPIFFS (" + String(written) + " bytes)");
+            }
         } else {
             logMessage("RESTORE ERROR: Failed to save ChatGPT prompts to SPIFFS");
         }
@@ -3277,10 +3303,15 @@ bool import_user_backup(const String& json_string, String& error_msg) {
 
         File imap_file = SPIFFS.open("/imap_settings.json", "w");
         if (imap_file) {
-            imap_file.print(imap_json);
+            size_t written = imap_file.print(imap_json);
+            imap_file.flush();
             imap_file.close();
 
-            logMessage("RESTORE: IMAP settings restored to SPIFFS (" + String(imap_json.length()) + " bytes)");
+            if (written == 0) {
+                logMessage("RESTORE ERROR: IMAP settings write failed (0 bytes)");
+            } else {
+                logMessage("RESTORE: IMAP settings restored to SPIFFS (" + String(written) + " bytes)");
+            }
         } else {
             logMessage("RESTORE ERROR: Failed to save IMAP settings to SPIFFS");
         }
@@ -3937,11 +3968,13 @@ bool chatgpt_save_config() {
     }
 
     if (serializeJsonPretty(doc, file) == 0) {
+        file.flush();
         file.close();
         logMessage("CHATGPT: Failed to write configuration file");
         return false;
     }
 
+    file.flush();
     file.close();
     logMessage("CHATGPT: Configuration saved successfully");
     return true;
@@ -9592,6 +9625,34 @@ void handle_upload_certificate() {
     uploaded_cert_data = "";
 }
 
+void flush_log_buffer_to_spiffs() {
+    if (log_buffer_len == 0) return;
+
+    File file = SPIFFS.open("/serial.log", "a");
+    if (file) {
+        file.write((const uint8_t*)log_buffer, log_buffer_len);
+        file.close();
+
+        File rf = SPIFFS.open("/serial.log", "r");
+        if (rf) {
+            size_t fileSize = rf.size();
+            rf.close();
+            if (fileSize > MAX_LOG_FILE_SIZE) {
+                trim_log_file();
+            }
+        }
+    }
+
+    log_buffer_len    = 0;
+    log_last_flush_ms = millis();
+}
+
+void flush_log_buffer_if_due() {
+    if (log_buffer_len > 0 && (millis() - log_last_flush_ms) >= LOG_FLUSH_INTERVAL_MS) {
+        flush_log_buffer_to_spiffs();
+    }
+}
+
 void trim_log_file() {
     File file = SPIFFS.open("/serial.log", "r");
     if (!file) return;
@@ -9642,16 +9703,18 @@ void append_to_log_file(const char* message) {
                  timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec, message);
     }
 
-    File file = SPIFFS.open("/serial.log", "a");
-    if (file) {
-        file.print(logLine);
-        file.flush();
-        size_t currentSize = file.size();
-        file.close();
+    size_t lineLen = strlen(logLine);
+    if (log_buffer_len + lineLen >= LOG_BUFFER_SIZE) {
+        flush_log_buffer_to_spiffs();
+    }
 
-        if (currentSize > MAX_LOG_FILE_SIZE) {
-            trim_log_file();
-        }
+    if (lineLen < LOG_BUFFER_SIZE) {
+        memcpy(log_buffer + log_buffer_len, logLine, lineLen);
+        log_buffer_len += lineLen;
+    }
+
+    if (log_buffer_len >= LOG_FLUSH_THRESHOLD) {
+        flush_log_buffer_to_spiffs();
     }
 }
 
@@ -11513,6 +11576,8 @@ void check_power_disconnect_alert(bool power_connected, bool charging_active) {
 void loop() {
 
     unsigned long now = millis();
+
+    flush_log_buffer_if_due();
 
     switch (boot_phase) {
         case BOOT_INIT:

--- a/Firmware/flex-fsk-tx-v3.6_WiFi/flex-fsk-tx-v3.6_WiFi.ino
+++ b/Firmware/flex-fsk-tx-v3.6_WiFi/flex-fsk-tx-v3.6_WiFi.ino
@@ -195,7 +195,7 @@
  * v3.6.104 - PERSISTENT SPIFFS LOG SYSTEM: Implemented /serial.log file (250KB limit, 50KB keep on rotate),
  *            single logMessage() function handles all logging (Serial + file + syslog), deleted old log buffers
  *            (12KB freed), pre-NTP timestamps show uptime (0000-00-00 HH:MM:SS), post-NTP show datetime
- *            (YYYY-MM-DD HH:MM:SS), file.flush() ensures writes committed to flash, AT+GETLOG=N (default 25)
+ *            (YYYY-MM-DD HH:MM:SS), file.flush() ensures writes committed to flash, AT+LOGS?N (default 25)
  *            and AT+RMLOG commands, status page displays 100 lines with auto-scroll to bottom, chronological
  *            order (oldest→newest), live logs toggle with configurable refresh interval (1-60s, default 5s)
  *            and lines count (10-500, default 100), both apply immediately on blur, simple polling every N
@@ -10768,7 +10768,7 @@ bool at_parse_command(char* cmd_buffer) {
         return true;
     }
 
-    else if (strcmp(cmd_name, "GETLOG") == 0) {
+    else if (strcmp(cmd_name, "LOGS") == 0) {
         if (!SPIFFS.exists("/serial.log")) {
             Serial.println("ERROR: No log file found");
             at_send_ok();
@@ -10776,8 +10776,8 @@ bool at_parse_command(char* cmd_buffer) {
         }
 
         int numLines = 25;
-        if (equals_pos != NULL) {
-            numLines = atoi(equals_pos + 1);
+        if (query_pos != NULL) {
+            numLines = atoi(query_pos + 1);
             if (numLines <= 0) numLines = 25;
         }
 

--- a/Firmware/flex-fsk-tx-v3.8_GSM/flex-fsk-tx-v3.8_GSM.ino
+++ b/Firmware/flex-fsk-tx-v3.8_GSM/flex-fsk-tx-v3.8_GSM.ino
@@ -76,7 +76,7 @@
  * v3.8.58  - PERSISTENT SPIFFS LOG SYSTEM: Implemented /serial.log file (250KB limit, 50KB keep on rotate),
  *            single logMessage() function handles all logging (Serial + file + syslog), deleted old log buffers
  *            (12KB freed), pre-NTP timestamps show uptime (0000-00-00 HH:MM:SS), post-NTP show datetime
- *            (YYYY-MM-DD HH:MM:SS), file.flush() ensures writes committed to flash, AT+GETLOG=N (default 25)
+ *            (YYYY-MM-DD HH:MM:SS), file.flush() ensures writes committed to flash, AT+LOGS?N (default 25)
  *            and AT+RMLOG commands, status page displays 100 lines with auto-scroll to bottom, chronological
  *            order (oldest→newest), live logs toggle with configurable refresh interval (1-60s, default 5s)
  * v3.8.59  - RTC TIME INTEGRATION: Log timestamps now use system_time_initialized flag instead of ntp_synced,
@@ -12635,7 +12635,7 @@ bool at_parse_command(char* cmd_buffer) {
         return true;
     }
 
-    else if (strcmp(cmd_name, "GETLOG") == 0) {
+    else if (strcmp(cmd_name, "LOGS") == 0) {
         if (!SPIFFS.exists("/serial.log")) {
             Serial.println("ERROR: No log file found");
             at_send_ok();
@@ -12643,8 +12643,8 @@ bool at_parse_command(char* cmd_buffer) {
         }
 
         int numLines = 25;
-        if (equals_pos != NULL) {
-            numLines = atoi(equals_pos + 1);
+        if (query_pos != NULL) {
+            numLines = atoi(query_pos + 1);
             if (numLines <= 0) numLines = 25;
         }
 

--- a/Firmware/flex-fsk-tx-v3.8_GSM/flex-fsk-tx-v3.8_GSM.ino
+++ b/Firmware/flex-fsk-tx-v3.8_GSM/flex-fsk-tx-v3.8_GSM.ino
@@ -86,9 +86,16 @@
  *            still runs to verify/update RTC when network available
  * v3.8.60  - STATUS PAGE UX FIX: Lines count input now refreshes log display immediately when changed,
  *            works even with live logs disabled (calls pollLogs() after updating linesToShow variable)
+ * v3.8.61  - SPIFFS LOG SIZE FIX + LOG WRITE BUFFER: Corrected MAX_LOG_FILE_SIZE (256000->32768) and
+ *            LOG_TRUNCATE_SIZE (51200->8192) to fit within 128KB SPIFFS partition (min_spiffs scheme);
+ *            replaced per-message open/write/flush/close with 2KB RAM buffer; flushes to SPIFFS as single
+ *            write when full (>=1536B) or every 1s via loop()
+ * v3.8.62  - SPIFFS WRITE HARDENING: Added file.flush() before file.close() in all config write functions
+ *            (saveCertificateToSPIFFS, save_imap_config, save_runtime_settings, chatgpt_save_config, restore
+ *            handler); restore handler now checks print() return value and logs error on 0-byte write
 */
 
-#define CURRENT_VERSION "v3.8.60"
+#define CURRENT_VERSION "v3.8.62"
 
 /*
  * ============================================================================
@@ -334,8 +341,15 @@ using TinyGsmClientSim800 = TinyGsmNS800::TinyGsmSim800::GsmClientSim800;
 #define CONFIG_MAGIC 0xF1E7
 #define CONFIG_VERSION 3
 
-#define MAX_LOG_FILE_SIZE 256000
-#define LOG_TRUNCATE_SIZE 51200
+#define MAX_LOG_FILE_SIZE     32768
+#define LOG_TRUNCATE_SIZE     8192
+#define LOG_BUFFER_SIZE       2048
+#define LOG_FLUSH_INTERVAL_MS 1000
+#define LOG_FLUSH_THRESHOLD   (LOG_BUFFER_SIZE * 3 / 4)
+
+static char     log_buffer[LOG_BUFFER_SIZE];
+static size_t   log_buffer_len    = 0;
+static uint32_t log_last_flush_ms = 0;
 
 #define CHECK_HEAP(size) (ESP.getFreeHeap() > (size + 8192))
 
@@ -1370,6 +1384,7 @@ bool saveCertificateToSPIFFS(const char* filename, const String& cert) {
     }
 
     size_t bytesWritten = file.print(cert);
+    file.flush();
     file.close();
     return (bytesWritten > 0);
 }
@@ -3721,10 +3736,12 @@ bool save_imap_config() {
 
     if (serializeJson(doc, file) == 0) {
         logMessage("IMAP: Failed to write IMAP config JSON");
+        file.flush();
         file.close();
         return false;
     }
 
+    file.flush();
     file.close();
     logMessage("IMAP: Config saved successfully");
     return true;
@@ -3911,10 +3928,12 @@ bool save_runtime_settings() {
 
     if (serializeJson(doc, file) == 0) {
         logMessage("SETTINGS: Failed to write settings JSON");
+        file.flush();
         file.close();
         return false;
     }
 
+    file.flush();
     file.close();
     logMessage("SETTINGS: Configuration saved successfully");
     return true;
@@ -4825,11 +4844,16 @@ bool import_user_backup(const String& json_string, String& error_msg) {
 
         File chatgpt_file = SPIFFS.open("/chatgpt_settings.json", "w");
         if (chatgpt_file) {
-            chatgpt_file.print(chatgpt_json);
+            size_t written = chatgpt_file.print(chatgpt_json);
+            chatgpt_file.flush();
             chatgpt_file.close();
 
-            chatgpt_load_config();
-            logMessage("RESTORE: ChatGPT prompts restored to SPIFFS (" + String(chatgpt_json.length()) + " bytes)");
+            if (written == 0) {
+                logMessage("RESTORE ERROR: ChatGPT prompts write failed (0 bytes)");
+            } else {
+                chatgpt_load_config();
+                logMessage("RESTORE: ChatGPT prompts restored to SPIFFS (" + String(written) + " bytes)");
+            }
         } else {
             logMessage("RESTORE ERROR: Failed to save ChatGPT prompts to SPIFFS");
         }
@@ -4843,10 +4867,15 @@ bool import_user_backup(const String& json_string, String& error_msg) {
 
         File imap_file = SPIFFS.open("/imap_settings.json", "w");
         if (imap_file) {
-            imap_file.print(imap_json);
+            size_t written = imap_file.print(imap_json);
+            imap_file.flush();
             imap_file.close();
 
-            logMessage("RESTORE: IMAP settings restored to SPIFFS (" + String(imap_json.length()) + " bytes)");
+            if (written == 0) {
+                logMessage("RESTORE ERROR: IMAP settings write failed (0 bytes)");
+            } else {
+                logMessage("RESTORE: IMAP settings restored to SPIFFS (" + String(written) + " bytes)");
+            }
         } else {
             logMessage("RESTORE ERROR: Failed to save IMAP settings to SPIFFS");
         }
@@ -5528,11 +5557,13 @@ bool chatgpt_save_config() {
     }
 
     if (serializeJsonPretty(doc, file) == 0) {
+        file.flush();
         file.close();
         logMessage("CHATGPT: Failed to write configuration file");
         return false;
     }
 
+    file.flush();
     file.close();
     logMessage("CHATGPT: Configuration saved successfully");
     return true;
@@ -13096,6 +13127,34 @@ void check_transmission_task_health() {
 }
 
 
+void flush_log_buffer_to_spiffs() {
+    if (log_buffer_len == 0) return;
+
+    File file = SPIFFS.open("/serial.log", "a");
+    if (file) {
+        file.write((const uint8_t*)log_buffer, log_buffer_len);
+        file.close();
+
+        File rf = SPIFFS.open("/serial.log", "r");
+        if (rf) {
+            size_t fileSize = rf.size();
+            rf.close();
+            if (fileSize > MAX_LOG_FILE_SIZE) {
+                trim_log_file();
+            }
+        }
+    }
+
+    log_buffer_len    = 0;
+    log_last_flush_ms = millis();
+}
+
+void flush_log_buffer_if_due() {
+    if (log_buffer_len > 0 && (millis() - log_last_flush_ms) >= LOG_FLUSH_INTERVAL_MS) {
+        flush_log_buffer_to_spiffs();
+    }
+}
+
 void trim_log_file() {
     File file = SPIFFS.open("/serial.log", "r");
     if (!file) return;
@@ -13146,16 +13205,18 @@ void append_to_log_file(const char* message) {
                  timeinfo.tm_hour, timeinfo.tm_min, timeinfo.tm_sec, message);
     }
 
-    File file = SPIFFS.open("/serial.log", "a");
-    if (file) {
-        file.print(logLine);
-        file.flush();
-        size_t currentSize = file.size();
-        file.close();
+    size_t lineLen = strlen(logLine);
+    if (log_buffer_len + lineLen >= LOG_BUFFER_SIZE) {
+        flush_log_buffer_to_spiffs();
+    }
 
-        if (currentSize > MAX_LOG_FILE_SIZE) {
-            trim_log_file();
-        }
+    if (lineLen < LOG_BUFFER_SIZE) {
+        memcpy(log_buffer + log_buffer_len, logLine, lineLen);
+        log_buffer_len += lineLen;
+    }
+
+    if (log_buffer_len >= LOG_FLUSH_THRESHOLD) {
+        flush_log_buffer_to_spiffs();
     }
 }
 
@@ -13496,6 +13557,8 @@ void loop() {
     unsigned long now = millis();
     bool wifi_runtime_enabled = (network_mode == NETWORK_MODE_AUTO || network_mode == NETWORK_MODE_WIFI);
     bool gsm_runtime_enabled = (network_mode == NETWORK_MODE_AUTO || network_mode == NETWORK_MODE_GSM) && gsm_config.enable_gsm;
+
+    flush_log_buffer_if_due();
 
     switch (boot_phase) {
         case BOOT_INIT:

--- a/docs/AT_COMMANDS.md
+++ b/docs/AT_COMMANDS.md
@@ -134,6 +134,21 @@ print(ser.readline().decode())
 | `AT+SAVE` | Execute | None | `OK` / `ERROR` | v3 | Save configuration to NVS |
 | `AT+FACTORYRESET` | Execute | None | `OK` (then restart) | v3 | Reset to factory defaults |
 
+### Log & Diagnostics Commands (v3.6+ Firmware)
+
+| Command | Type | Parameters | Response | Firmware | Description |
+|---------|------|------------|----------|----------|-------------|
+| `AT+LOGS?` | Query | None | Last 25 log lines + `OK` | v3.6, v3.8 | Query last 25 lines of persistent log |
+| `AT+LOGS?N` | Query | `N`: number of lines | Last N log lines + `OK` | v3.6, v3.8 | Query last N lines of persistent log |
+| `AT+RMLOG` | Execute | None | `LOG: File deleted` + `OK` | v3.6, v3.8 | Delete persistent log file |
+
+### Network Transport Commands (v3.8 GSM Firmware Only)
+
+| Command | Type | Parameters | Response | Firmware | Description |
+|---------|------|------------|----------|----------|-------------|
+| `AT+NETWORK?` | Query | None | `+NETWORK: <mode>` | v3.8 | Query current network transport mode |
+| `AT+NETWORK=<mode>` | Set | `AUTO`, `WIFI`, `GSM`, `AP` | `OK` / `ERROR` | v3.8 | Lock network transport mode |
+
 ## 🔄 Device Status States
 
 | Status | Description |
@@ -248,6 +263,66 @@ AT+SAVE
 # Factory reset (restores all defaults)
 AT+FACTORYRESET
 ```
+
+### Persistent Log Commands (v3.6+ Firmware)
+
+```bash
+# Query last 25 lines of log (default)
+AT+LOGS?
+# Response: timestamped log lines (oldest→newest)
+# OK
+
+# Query last 50 lines
+AT+LOGS?50
+
+# Query last 10 lines
+AT+LOGS?10
+
+# Delete log file
+AT+RMLOG
+# Response: LOG: File deleted
+# OK
+
+# If no log file exists:
+AT+LOGS?
+# Response: ERROR: No log file found
+# OK
+```
+
+**Log File Details**:
+- **File**: `/serial.log` on SPIFFS
+- **Max Size**: 250KB (auto-rotates, keeps last 50KB)
+- **Timestamp Format (pre-NTP/RTC)**: `0000-00-00 HH:MM:SS` (uptime-based)
+- **Timestamp Format (post-NTP/RTC)**: `YYYY-MM-DD HH:MM:SS`
+- **Order**: Chronological (oldest → newest)
+
+### Network Transport Mode (v3.8 GSM Firmware Only)
+
+```bash
+# Query current network transport mode
+AT+NETWORK?
+# Response: +NETWORK: AUTO
+
+# Lock to WiFi only (disables automatic fallback)
+AT+NETWORK=WIFI
+
+# Lock to GSM only
+AT+NETWORK=GSM
+
+# Force AP mode
+AT+NETWORK=AP
+
+# Return to automatic failover
+AT+NETWORK=AUTO
+```
+
+**Network Mode Behavior**:
+- **AUTO**: Default. Automatic WiFi → GSM → AP failover
+- **WIFI**: WiFi only, retries every 60 seconds if disconnected
+- **GSM**: GSM only, retries every 300 seconds (5 minutes) if disconnected
+- **AP**: Access Point mode, no retries
+- **Display**: Shows asterisk when locked (e.g., `WiFi*`, `GSM*`, `AP*`)
+- **Reset**: Mode resets to AUTO on reboot or manual mode change
 
 ## 🚨 Error Handling
 

--- a/docs/FIRMWARE.md
+++ b/docs/FIRMWARE.md
@@ -85,6 +85,9 @@ Firmware/flex-fsk-tx-v2/
 - ChatGPT scheduled prompts
 - Message queue (up to 25 messages)
 - Remote syslog logging
+- Persistent SPIFFS log system (`/serial.log`, 250KB, auto-rotation)
+- Log query via AT commands (`AT+LOGS?N`, `AT+RMLOG`) and REST (`/logs?lines=N`)
+- RTC time integration for immediate boot timestamps
 - Requires `min_spiffs` partition scheme
 
 ### v3.8 - WiFi + GSM/Cellular Support
@@ -94,6 +97,7 @@ Firmware/flex-fsk-tx-v2/
 - Dual-transport MQTT/IMAP/ChatGPT (WiFi or GSM)
 - GSM-aware service throttling to preserve bandwidth
 - Network health monitoring with display indicators
+- Network transport mode control (`AT+NETWORK` command) for locking WiFi/GSM/AP mode
 - GSM pin definitions in `include/boards/boards.h`
 - Requires `min_spiffs` partition scheme
 
@@ -564,6 +568,45 @@ AT+PPM=1.23
 
 # Monitor serial for watchdog task registration logs
 # Should see proper task registration on boot
+```
+
+**Test Persistent Log System** (v3.6.104+):
+```bash
+# Query last 25 log lines (default)
+AT+LOGS?
+# Expected: timestamped log lines + OK
+
+# Query specific number of lines
+AT+LOGS?50
+# Expected: last 50 log lines + OK
+
+# Delete log file
+AT+RMLOG
+# Expected: LOG: File deleted + OK
+
+# Test web log endpoint
+curl -s http://DEVICE_IP/logs?lines=20
+# Expected: JSON with {"logs":[...]}
+
+# Download full log file
+curl -s http://DEVICE_IP/download_logs -o serial.log
+```
+
+### 6. v3.8 GSM Feature Testing
+
+**Test Network Transport Mode** (v3.8.52+):
+```bash
+# Query current mode
+AT+NETWORK?
+# Expected: +NETWORK: AUTO
+
+# Lock to WiFi
+AT+NETWORK=WIFI
+# Expected: OK (display shows WiFi*)
+
+# Return to automatic failover
+AT+NETWORK=AUTO
+# Expected: OK
 ```
 
 ## 🚨 Troubleshooting

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -880,6 +880,59 @@ AT+ABORT  # Cancel operation
 
 ## 🔍 Diagnostic Information Collection
 
+### Using Persistent Logs for Debugging (v3.6.104+)
+
+The v3.6+ firmware includes a persistent log system that records all device activity to SPIFFS. This is the most effective tool for diagnosing issues.
+
+**Accessing Logs via AT Commands**:
+```bash
+# View last 25 log lines (default)
+AT+LOGS?
+
+# View last 100 log lines for detailed analysis
+AT+LOGS?100
+
+# Clear log file (useful before reproducing an issue)
+AT+RMLOG
+```
+
+**Accessing Logs via Web Interface**:
+1. Navigate to `http://DEVICE_IP/status`
+2. Scroll to the log display section
+3. Enable **Live Logs** toggle for real-time monitoring
+4. Adjust **Refresh Interval** (1-60s) and **Lines** count (10-500) as needed
+5. Click **Download** to save full log file for offline analysis
+
+**Accessing Logs via REST API**:
+```bash
+# Get last 50 log lines as JSON
+curl -s http://DEVICE_IP/logs?lines=50
+
+# Download full log file
+curl -s http://DEVICE_IP/download_logs -o serial.log
+
+# Grep for specific issues
+curl -s http://DEVICE_IP/download_logs | grep -i "error\|fail\|timeout"
+```
+
+**Log Timestamps**:
+- Before NTP/RTC sync: `0000-00-00 HH:MM:SS` (uptime since boot)
+- After NTP/RTC sync: `YYYY-MM-DD HH:MM:SS` (real datetime)
+- RTC-equipped devices get real timestamps immediately at boot
+
+**Log File Details**:
+- File: `/serial.log` on SPIFFS
+- Max size: 250KB (auto-rotates, keeps last 50KB)
+- Survives reboots (persistent across power cycles)
+- All logging consolidated through `logMessage()` function
+
+**Debugging Workflow**:
+1. Clear log: `AT+RMLOG`
+2. Reproduce the issue
+3. Retrieve log: `AT+LOGS?100` or download via web
+4. Look for ERROR, FAIL, or TIMEOUT entries
+5. Include relevant log sections in bug reports
+
 ### Device Information Gathering
 
 When reporting issues, collect this diagnostic information:
@@ -903,6 +956,10 @@ AT+WIFICONFIG?
 AT+APIPORT?
 AT+APIUSER?
 AT+BATTERY?
+AT+LOGS?50
+
+# For v3.8 GSM firmware only:
+AT+NETWORK?
 
 # Hardware test
 AT+FREQ=915.0

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -279,11 +279,16 @@ Access via `/status` or click "Status" link.
   - Messages sent
   - Severity filter level
 
-**Recent Serial Messages**:
-- Last 50 serial log messages
-- Live updates every 2 seconds (no page reload)
-- Scrollable message area
-- Severity-based filtering
+**Persistent Device Logs** (v3.6.104+):
+- Reads from persistent SPIFFS log file (`/serial.log`)
+- Displays configurable number of log lines (10-500, default 100)
+- Chronological order (oldest → newest) with auto-scroll to bottom
+- **Live Logs Toggle**: Enable/disable automatic log polling
+- **Refresh Interval**: Configurable 1-60 seconds (default 5s), applies immediately
+- **Lines Count**: Adjustable 10-500 lines, refreshes display immediately on change
+- **Download Button**: Download full log file for offline analysis
+- Scrollable container (500px max-height)
+- Timestamps: `YYYY-MM-DD HH:MM:SS` (or `0000-00-00 HH:MM:SS` before time sync)
 
 **Device Management**:
 - **Factory Reset**: Reset device to defaults
@@ -334,6 +339,9 @@ Hello World!          # Type message and press Enter
 AT+WIFI?              # Check WiFi status
 AT+STATUS?            # Check device status
 AT+FREQPPM=4.30       # Set PPM correction (0.02 precision)
+AT+LOGS?              # View last 25 log lines
+AT+LOGS?50            # View last 50 log lines
+AT+RMLOG              # Delete log file
 ```
 
 **When to Use AT Commands**:
@@ -586,6 +594,8 @@ After factory reset, repeat the initial WiFi setup process.
 - ChatGPT scheduled prompts
 - Grafana webhook integration
 - Remote syslog logging (RFC 3164)
+- Persistent SPIFFS log system with web UI, AT commands, and REST endpoint
+- RTC time integration for immediate boot timestamps
 - Enhanced PPM correction precision (0.02 decimals)
 - Improved watchdog stability
 - Memory optimization (chunked HTTP responses)


### PR DESCRIPTION
  PERSISTENT SPIFFS LOG SYSTEM (v3.6.104 WiFi, v3.8.58 GSM):
  - Implemented /serial.log file (250KB limit, 50KB keep on rotate)
  - Single logMessage() function handles all logging (Serial + file + syslog)
  - Deleted old log buffers (12KB RAM freed)
  - Pre-NTP timestamps show uptime (0000-00-00 HH:MM:SS)
  - Post-NTP timestamps show datetime (YYYY-MM-DD HH:MM:SS)
  - file.flush() ensures writes committed to flash
  - AT+GETLOG=N (default 25) and AT+RMLOG commands
  - Status page displays 100 lines with auto-scroll on initial page load
  - Chronological order (oldest→newest)
  - Live logs toggle with configurable refresh interval (1-60s, default 5s)
  - Lines count configurable (10-500, default 100)
  - Both settings apply immediately on blur
  - Simple polling every N seconds (no timestamp filtering)
  - Scrollable container (500px max-height)
  - Download button for full log file
  - /logs API accepts ?lines=N parameter
  - Boot logging starts immediately after SPIFFS init
  - sendSyslog() now detects severity internally (better encapsulation)

  WEB UI IMPROVEMENTS:
  - Theme-aware input field styling
  - Download button moved to end of controls row
  - Auto-scroll only on initial page load (user maintains scroll position)
