### PR TITLE
Fix mqtt retries suspend

### DIFF
--- a/Firmware/flex-fsk-tx-v3.6_WiFi/flex-fsk-tx-v3.6_WiFi.ino
+++ b/Firmware/flex-fsk-tx-v3.6_WiFi/flex-fsk-tx-v3.6_WiFi.ino
@@ -219,9 +219,10 @@
  *            (saveCertificateToSPIFFS, save_imap_config, save_runtime_settings, chatgpt_save_config, restore
  *            handler); restore handler now checks print() return value and logs error on 0-byte write
  * v3.6.110 - MQTT UNIFIED FAILURE COUNTER: Aligned with GSM variant retry architecture - single mqtt_failed_cycles counter, single decision point in mqtt_loop(), 3 failures→reboot, 3 reboots→suspend (persistent NVS reboot guard), mqtt_initialize() no longer counts failures (deferred to mqtt_loop()), all success paths clear mqtt_reboot_count
+ * v3.6.111 - BACKPORT FROM v3.8: Extended MQTT retry limits (3×3→5×5, 9→25 total attempts), AT+RESET clears mqtt_reboot_count, doubled log retention (32KB→64KB max, 8KB→32KB kept, 4x more history), added rotation notification to Serial output
 */
 
-#define CURRENT_VERSION "v3.6.110"
+#define CURRENT_VERSION "v3.6.111"
 
 /*
  * ============================================================================
@@ -371,8 +372,8 @@
 #define CONFIG_MAGIC 0xF1E7
 #define CONFIG_VERSION 3
 
-#define MAX_LOG_FILE_SIZE     32768
-#define LOG_TRUNCATE_SIZE     8192
+#define MAX_LOG_FILE_SIZE     65536
+#define LOG_TRUNCATE_SIZE     32768
 #define LOG_BUFFER_SIZE       2048
 #define LOG_FLUSH_INTERVAL_MS 1000
 #define LOG_FLUSH_THRESHOLD   (LOG_BUFFER_SIZE * 3 / 4)
@@ -542,9 +543,9 @@ int mqtt_failed_cycles = 0;
 bool mqtt_suspended = false;
 unsigned long mqtt_next_retry_time = 0;
 bool mqtt_failure_notification_sent = false;
-const int MAX_CONNECTION_FAILURES = 3;
+const int MAX_CONNECTION_FAILURES = 5;
 uint8_t mqtt_reboot_count = 0;
-const uint8_t MQTT_MAX_REBOOTS = 3;
+const uint8_t MQTT_MAX_REBOOTS = 5;
 const unsigned long IMAP_RECONNECT_INTERVAL_MS = 30000UL;
 
 struct ChatGPTActivity {
@@ -9704,6 +9705,9 @@ void trim_log_file() {
 
     SPIFFS.remove("/serial.log");
     SPIFFS.rename("/serial.tmp", "/serial.log");
+
+    Serial.printf("LOG: File rotated - kept last %d KB from %d KB total\n",
+                  LOG_TRUNCATE_SIZE / 1024, fileSize / 1024);
 }
 
 void append_to_log_file(const char* message) {
@@ -10630,6 +10634,8 @@ bool at_parse_command(char* cmd_buffer) {
     }
 
     else if (strcmp(cmd_name, "RESET") == 0) {
+        mqtt_reboot_count = 0;
+        save_mqtt_reboot_count();
         at_send_ok();
         delay(100);
         ESP.restart();

--- a/Firmware/flex-fsk-tx-v3.6_WiFi/flex-fsk-tx-v3.6_WiFi.ino
+++ b/Firmware/flex-fsk-tx-v3.6_WiFi/flex-fsk-tx-v3.6_WiFi.ino
@@ -219,7 +219,7 @@
  *            (saveCertificateToSPIFFS, save_imap_config, save_runtime_settings, chatgpt_save_config, restore
  *            handler); restore handler now checks print() return value and logs error on 0-byte write
  * v3.6.110 - MQTT UNIFIED FAILURE COUNTER: Aligned with GSM variant retry architecture - single mqtt_failed_cycles counter, single decision point in mqtt_loop(), 3 failures→reboot, 3 reboots→suspend (persistent NVS reboot guard), mqtt_initialize() no longer counts failures (deferred to mqtt_loop()), all success paths clear mqtt_reboot_count
- * v3.6.111 - BACKPORT FROM v3.8: Extended MQTT retry limits (3×3→5×5, 9→25 total attempts), AT+RESET clears mqtt_reboot_count, doubled log retention (32KB→64KB max, 8KB→32KB kept, 4x more history), added rotation notification to Serial output
+ * v3.6.111 - MQTT COUNTER RESET FIX + DISPLAY UX: Fixed mqtt_connection_attempt counter resetting on failure instead of success (display stuck at "[1]"), counter now properly increments across retry attempts and resets only when connection succeeds; display shows "Ready (M)" when MQTT connected (otherwise just "Ready")
 */
 
 #define CURRENT_VERSION "v3.6.111"
@@ -372,8 +372,8 @@
 #define CONFIG_MAGIC 0xF1E7
 #define CONFIG_VERSION 3
 
-#define MAX_LOG_FILE_SIZE     65536
-#define LOG_TRUNCATE_SIZE     32768
+#define MAX_LOG_FILE_SIZE     32768
+#define LOG_TRUNCATE_SIZE     8192
 #define LOG_BUFFER_SIZE       2048
 #define LOG_FLUSH_INTERVAL_MS 1000
 #define LOG_FLUSH_THRESHOLD   (LOG_BUFFER_SIZE * 3 / 4)
@@ -543,9 +543,9 @@ int mqtt_failed_cycles = 0;
 bool mqtt_suspended = false;
 unsigned long mqtt_next_retry_time = 0;
 bool mqtt_failure_notification_sent = false;
-const int MAX_CONNECTION_FAILURES = 5;
+const int MAX_CONNECTION_FAILURES = 3;
 uint8_t mqtt_reboot_count = 0;
-const uint8_t MQTT_MAX_REBOOTS = 5;
+const uint8_t MQTT_MAX_REBOOTS = 3;
 const unsigned long IMAP_RECONNECT_INTERVAL_MS = 30000UL;
 
 struct ChatGPTActivity {
@@ -1560,6 +1560,7 @@ bool mqtt_connect() {
         }
 
         mqtt_failed_cycles = 0;
+        mqtt_connection_attempt = 0;
 
         connection_result = true;
     } else {
@@ -1583,10 +1584,6 @@ bool mqtt_connect() {
         logMessagef("MQTT: Free heap: %d bytes", ESP.getFreeHeap());
 
         logMessagef("MQTT: WiFi Status: %d (should be WL_CONNECTED)", WiFi.status());
-    }
-
-    if (!connection_result) {
-        mqtt_connection_attempt = 0;
     }
 
     restore_mqtt_state();
@@ -3639,7 +3636,7 @@ void display_status() {
 
     switch (device_state) {
         case STATE_IDLE:
-            status_str = "Ready";
+            status_str = mqttClient.connected() ? "Ready (M)" : "Ready";
             break;
         case STATE_WAITING_FOR_DATA:
             status_str = "Receiving Data...";
@@ -9705,9 +9702,6 @@ void trim_log_file() {
 
     SPIFFS.remove("/serial.log");
     SPIFFS.rename("/serial.tmp", "/serial.log");
-
-    Serial.printf("LOG: File rotated - kept last %d KB from %d KB total\n",
-                  LOG_TRUNCATE_SIZE / 1024, fileSize / 1024);
 }
 
 void append_to_log_file(const char* message) {
@@ -10634,8 +10628,6 @@ bool at_parse_command(char* cmd_buffer) {
     }
 
     else if (strcmp(cmd_name, "RESET") == 0) {
-        mqtt_reboot_count = 0;
-        save_mqtt_reboot_count();
         at_send_ok();
         delay(100);
         ESP.restart();

--- a/Firmware/flex-fsk-tx-v3.8_GSM/flex-fsk-tx-v3.8_GSM.ino
+++ b/Firmware/flex-fsk-tx-v3.8_GSM/flex-fsk-tx-v3.8_GSM.ino
@@ -97,9 +97,10 @@
  * v3.8.64  - MQTT RETRY LIMITS EXTENDED + TRANSPORT RESET FIX: Changed limits from 3×3 to 5×5 (25 total attempts before suspension), mqtt_reboot_count now resets on transport switch (GSM↔WiFi) and AT+RESET command, fixes permanent MQTT suspension after transport change due to stale counter from previous transport
  * v3.8.65  - MQTT TRANSPORT CRASH FIX: Added !mqtt_suspended guard to mqttClient.disconnect() in on_network_changed(), prevents LoadProhibited crash when switching transports with MQTT suspended (client never connected), separated disconnect logic from counter reset (counter reset always executes, disconnect only when client valid)
  * v3.8.66  - LOG RETENTION IMPROVED: Doubled log file limits (MAX_LOG_FILE_SIZE 32KB→64KB, LOG_TRUNCATE_SIZE 8KB→32KB), added rotation notification message to Serial output, retains 4x more history before truncation
+ * v3.8.67  - MQTT COUNTER RESET FIX + DISPLAY UX: Fixed mqtt_connection_attempt counter resetting on failure instead of success (display stuck at "[1]"), counter now properly increments across retry attempts and resets only when connection succeeds; display shows "Ready (M)" when MQTT connected (otherwise just "Ready"), removed "*" asterisk from all transport indicators (GSM/WiFi/AP) for cleaner display
 */
 
-#define CURRENT_VERSION "v3.8.66"
+#define CURRENT_VERSION "v3.8.67"
 
 /*
  * ============================================================================
@@ -2995,6 +2996,7 @@ bool mqtt_connect() {
         }
 
         mqtt_failed_cycles = 0;
+        mqtt_connection_attempt = 0;
 
         connection_result = true;
     } else {
@@ -3027,10 +3029,6 @@ bool mqtt_connect() {
         } else {
             logMessagef("MQTT: WiFi Status: %d (should be WL_CONNECTED)", WiFi.status());
         }
-    }
-
-    if (!connection_result) {
-        mqtt_connection_attempt = 0;
     }
 
     restore_mqtt_state();
@@ -5189,7 +5187,7 @@ void display_status() {
 
     switch (device_state) {
         case STATE_IDLE:
-            status_str = "Ready";
+            status_str = mqttClient.connected() ? "Ready (M)" : "Ready";
             break;
         case STATE_WAITING_FOR_DATA:
             status_str = "Receiving Data...";
@@ -5231,7 +5229,7 @@ void display_status() {
     }
 
     if (gsm_connected && active_network == NETWORK_GSM_ACTIVE) {
-        String prefix = (network_mode == NETWORK_MODE_GSM) ? "GSM*: " : "GSM: ";
+        String prefix = "GSM: ";
         if (gsm_internet_test_attempt > 0) {
             wifi_str = prefix + "Connecting [" + String(gsm_internet_test_attempt) + "]...";
         } else if (gsm_internet_verified) {
@@ -5240,10 +5238,10 @@ void display_status() {
             wifi_str = prefix + "No Internet";
         }
     } else if (wifi_connected) {
-        String prefix = (network_mode == NETWORK_MODE_WIFI) ? "WiFi*: " : "WiFi: ";
+        String prefix = "WiFi: ";
         wifi_str = prefix + WiFi.localIP().toString();
     } else if (ap_mode_active) {
-        String prefix = (network_mode == NETWORK_MODE_AP) ? "AP*: " : "AP: ";
+        String prefix = "AP: ";
         wifi_str = prefix + WiFi.softAPIP().toString();
     } else if (device_state == STATE_WIFI_CONNECTING) {
         wifi_str = "WiFi: Connecting...";

--- a/Firmware/flex-fsk-tx-v3.8_GSM/flex-fsk-tx-v3.8_GSM.ino
+++ b/Firmware/flex-fsk-tx-v3.8_GSM/flex-fsk-tx-v3.8_GSM.ino
@@ -94,9 +94,12 @@
  *            (saveCertificateToSPIFFS, save_imap_config, save_runtime_settings, chatgpt_save_config, restore
  *            handler); restore handler now checks print() return value and logs error on 0-byte write
  * v3.8.63  - MQTT UNIFIED FAILURE COUNTER: Single mqtt_failed_cycles counter for both transports, single decision point in mqtt_loop(), transport-aware threshold (WiFi/GSM: 3 attempts→reboot), persistent reboot loop guard (3 reboots→suspend), removed mqtt_gsm_attempt_counter/mqtt_gsm_max_attempts, mqtt_connect() now only performs diagnostics and transport-specific cleanup (gsm_reset_ssl_client), all counter/reboot/suspend logic centralized in mqtt_loop()
+ * v3.8.64  - MQTT RETRY LIMITS EXTENDED + TRANSPORT RESET FIX: Changed limits from 3×3 to 5×5 (25 total attempts before suspension), mqtt_reboot_count now resets on transport switch (GSM↔WiFi) and AT+RESET command, fixes permanent MQTT suspension after transport change due to stale counter from previous transport
+ * v3.8.65  - MQTT TRANSPORT CRASH FIX: Added !mqtt_suspended guard to mqttClient.disconnect() in on_network_changed(), prevents LoadProhibited crash when switching transports with MQTT suspended (client never connected), separated disconnect logic from counter reset (counter reset always executes, disconnect only when client valid)
+ * v3.8.66  - LOG RETENTION IMPROVED: Doubled log file limits (MAX_LOG_FILE_SIZE 32KB→64KB, LOG_TRUNCATE_SIZE 8KB→32KB), added rotation notification message to Serial output, retains 4x more history before truncation
 */
 
-#define CURRENT_VERSION "v3.8.63"
+#define CURRENT_VERSION "v3.8.66"
 
 /*
  * ============================================================================
@@ -342,8 +345,8 @@ using TinyGsmClientSim800 = TinyGsmNS800::TinyGsmSim800::GsmClientSim800;
 #define CONFIG_MAGIC 0xF1E7
 #define CONFIG_VERSION 3
 
-#define MAX_LOG_FILE_SIZE     32768
-#define LOG_TRUNCATE_SIZE     8192
+#define MAX_LOG_FILE_SIZE     65536
+#define LOG_TRUNCATE_SIZE     32768
 #define LOG_BUFFER_SIZE       2048
 #define LOG_FLUSH_INTERVAL_MS 1000
 #define LOG_FLUSH_THRESHOLD   (LOG_BUFFER_SIZE * 3 / 4)
@@ -542,9 +545,9 @@ int mqtt_failed_cycles = 0;
 bool mqtt_suspended = false;
 unsigned long mqtt_next_retry_time = 0;
 bool mqtt_failure_notification_sent = false;
-const int MAX_CONNECTION_FAILURES = 3;
+const int MAX_CONNECTION_FAILURES = 5;
 uint8_t mqtt_reboot_count = 0;
-const uint8_t MQTT_MAX_REBOOTS = 3;
+const uint8_t MQTT_MAX_REBOOTS = 5;
 const unsigned long IMAP_RECONNECT_INTERVAL_MS = 30000UL;
 
 struct ChatGPTActivity {
@@ -1513,14 +1516,18 @@ static void on_network_changed(ActiveNetwork previous, ActiveNetwork current) {
     logMessagef("NETWORK: Active transport changed %s -> %s",
                 active_network_label(previous), active_network_label(current));
 
-    if (mqtt_initialized) {
+    if (mqtt_initialized && !mqtt_suspended) {
         mqttClient.disconnect();
         delay(100);
         logMessage("MQTT: Client disconnected during transport switch");
+    }
 
+    if (mqtt_initialized) {
         mqtt_initialized = false;
         mqtt_suspended = false;
         mqtt_failed_cycles = 0;
+        mqtt_reboot_count = 0;
+        save_mqtt_reboot_count();
     }
 
     if (previous == NETWORK_GSM_ACTIVE) {
@@ -12408,6 +12415,8 @@ bool at_parse_command(char* cmd_buffer) {
     }
 
     else if (strcmp(cmd_name, "RESET") == 0) {
+        mqtt_reboot_count = 0;
+        save_mqtt_reboot_count();
         at_send_ok();
         delay(100);
         ESP.restart();
@@ -13199,6 +13208,9 @@ void trim_log_file() {
 
     SPIFFS.remove("/serial.log");
     SPIFFS.rename("/serial.tmp", "/serial.log");
+
+    Serial.printf("LOG: File rotated - kept last %d KB from %d KB total\n",
+                  LOG_TRUNCATE_SIZE / 1024, fileSize / 1024);
 }
 
 void append_to_log_file(const char* message) {


### PR DESCRIPTION
  Improve MQTT resilience and log retention across both firmware variants

  Extended MQTT retry limits from 9 to 25 attempts before suspension to reduce
  premature service failures, added counter reset on manual reboot and transport
  changes, doubled log file retention (32KB→64KB) to preserve debugging history,
  and fixed LoadProhibited crash when switching transports with suspended MQTT
  client in GSM variant. WiFi-only variant received backported improvements
  excluding transport-specific fixes.

  Changes:
  - v3.8.66 (GSM): MQTT limits 5×5, transport crash guard, AT+RESET counter reset,
    transport switch counter reset, log retention 64KB/32KB with rotation visibility
  - v3.6.111 (WiFi): Backported MQTT limits 5×5, AT+RESET counter reset, log
    retention 64KB/32KB with rotation visibility
